### PR TITLE
Folia compat updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <dependency>
             <groupId>me.carleslc.Simple-YAML</groupId>
             <artifactId>Simple-Yaml</artifactId>
-            <version>1.8.1</version>
+            <version>1.8.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.loohp</groupId>
     <artifactId>ImageFrame</artifactId>
-    <version>1.7.7.1</version>
+    <version>1.7.7.2</version>
     <packaging>jar</packaging>
 
     <name>ImageFrame</name>
@@ -216,7 +216,7 @@
         <dependency>
             <groupId>me.carleslc.Simple-YAML</groupId>
             <artifactId>Simple-Yaml</artifactId>
-            <version>1.8.4</version>
+            <version>1.8.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/loohp/imageframe/objectholders/AnimatedFakeMapManager.java
+++ b/src/main/java/com/loohp/imageframe/objectholders/AnimatedFakeMapManager.java
@@ -46,16 +46,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.map.MapView;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
@@ -97,7 +88,7 @@ public class AnimatedFakeMapManager implements Listener, Runnable {
     }
 
     public void run() {
-        Map<ItemFrame, FutureTask<Optional<ItemFrameInfo>>> entityTrackers = new HashMap<>();
+        Map<ItemFrame, FutureTask<Optional<ItemFrameInfo>>> entityTrackers = new IdentityHashMap<>();
         if (ImageFrame.handleAnimatedMapsOnMainThread) {
             for (Map.Entry<ItemFrame, Holder<AnimationData>> entry : itemFrames.entrySet()) {
                 ItemFrame itemFrame = entry.getKey();


### PR DESCRIPTION
This PR is based on the code from the PR by HSGamer looking to fix one of the issues with ImageFrames on Folia
( #35 )

Looking for feedback on a few things. There are 2 parts to this:
- 1. is re-writing the part of the animation handler that builds the map of itemframes to process
- 2. removing lines (currently commented) that seem like unnecessary caching.

I need input mainly for part 2, where I removed things without being 100% sure of the impact this would have to people using the animated frames. Is there a specific reason to cache frames that aren't attached to any plugin frame data? If so, is there another way to do this? This could possibly be hundreds of frames that don't need to be manually ticked that are ticking anyway.

Otherwise part 1 should be exactly equivalent except moved into another part of the class such that the one method is not so huge and easier to understand.