### PR TITLE
Establish all permissions as op required

### DIFF
--- a/common/src/main/resources/plugin.yml
+++ b/common/src/main/resources/plugin.yml
@@ -14,6 +14,24 @@ commands:
     description: Plugin main command
 
 permissions:
+  imageframe.player:
+    default: op
+    description: Allow players to access all commands for creating their own image maps
+    children:
+      imageframe.create: true
+      imageframe.overlay: true
+      imageframe.clone: true
+      imageframe.playback: true
+      imageframe.select: true
+      imageframe.markerr: true
+      imageframe.refresh: true
+      imageframe.rename: true
+      imageframe.info: true
+      imageframe.list: true
+      imageframe.delete: true
+      imageframe.get: true
+      imageframe.setaccess: true
+      imageframe.preference: true
   imageframe.create:
     default: true
     description: Allow players to create new image maps

--- a/common/src/main/resources/plugin.yml
+++ b/common/src/main/resources/plugin.yml
@@ -33,7 +33,7 @@ permissions:
       imageframe.setaccess: true
       imageframe.preference: true
   imageframe.create:
-    default: true
+    default: op
     description: Allow players to create new image maps
   imageframe.create.animated:
     default: op
@@ -42,40 +42,40 @@ permissions:
     default: op
     description: Allow players to create image maps for other players, applies to overlay and clone, bypasses owning limit
   imageframe.overlay:
-    default: true
+    default: op
     description: Allow players to overlay images on Vanilla maps
   imageframe.clone:
-    default: true
+    default: op
     description: Allow players to make deep copies of their own image maps
   imageframe.playback:
-    default: true
+    default: op
     description: Allow players to pause or set position of playback of their own animated image maps
   imageframe.select:
-    default: true
+    default: op
     description: Allow players to select item frames
   imageframe.marker:
-    default: true
+    default: op
     description: Allow players to add and remove markers on image maps
   imageframe.marker.unlimited:
     default: op
     description: Allow players to add unlimited markers on image maps
   imageframe.refresh:
-    default: true
+    default: op
     description: Allow players to refresh image maps
   imageframe.rename:
-    default: true
+    default: op
     description: Allow players to rename image maps
   imageframe.info:
-    default: true
+    default: op
     description: Allow players to view image map data
   imageframe.list:
-    default: true
+    default: op
     description: Allow players to list all image maps they've created
   imageframe.list.others:
     default: op
     description: Allow players to list all image maps a player have created
   imageframe.delete:
-    default: true
+    default: op
     description: Allow players to delete an image map they've created
   imageframe.purge:
     default: false
@@ -84,10 +84,10 @@ permissions:
     default: false
     description: Allow players to purge all image maps at once
   imageframe.get:
-    default: true
+    default: op
     description: Allow players to get an image map they've created
   imageframe.setaccess:
-    default: true
+    default: op
     description: Allow players to change access permissions of their image maps
   imageframe.adminbypass:
     default: op
@@ -102,7 +102,7 @@ permissions:
     default: op
     description: Allow players to migrate maps from supported plugins to ImageFrame
   imageframe.preference:
-    default: true
+    default: op
     description: Allow players to update their player preferences
   imageframe.preference.others:
     default: op


### PR DESCRIPTION
hello, after using this plugin on a production environment, we were unaware that players by default had access to import their own image from any source, and assumed it was locked behind permission as it should've been, we were swiftly mistaken.

Players having access to command that establishes a web connection, allowing them to import any image into the server with no way of tracking it is a severe oversight. The type of images that someone could just upload onto a server shouldn't need to be expressed.

I have implemented a new permission, `imageframe.player`, which can be granted to players to provide them access to all the previous permissions they had access to prior to this change.

I understand this change will result in a large influx of angry "my players have lost access to all their commands >:(" but, I think that is a valuable price to pay for the risk of highly graphic images being uploaded with no prior knowledge.

thank u!  