### PR TITLE
Excessive Data Creation Fix

### DIFF
--- a/common/src/main/java/com/loohp/imageframe/objectholders/IFPlayer.java
+++ b/common/src/main/java/com/loohp/imageframe/objectholders/IFPlayer.java
@@ -103,10 +103,16 @@ public class IFPlayer {
         JsonObject json = new JsonObject();
         json.addProperty("uuid", uuid.toString());
         JsonObject preferenceJson = new JsonObject();
+		int propertiesAdded = 0;
         for (Map.Entry<IFPlayerPreference<?>, Object> entry : preferences.entrySet()) {
             IFPlayerPreference<?> preference = entry.getKey();
-            preferenceJson.add(preference.getJsonName(), preference.getSerializer(Object.class).apply(entry.getValue()));
+			final Object value = entry.getValue();
+			if (value != preference.getDefaultValue(this)) {
+				preferenceJson.add(preference.getJsonName(), preference.getSerializer(Object.class).apply(entry.getValue()));
+				propertiesAdded++;
+			}
         }
+		if (propertiesAdded == 0) return;
         json.add("preferences", preferenceJson);
         try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
             pw.println(GSON.toJson(json));

--- a/common/src/main/java/com/loohp/imageframe/objectholders/IFPlayer.java
+++ b/common/src/main/java/com/loohp/imageframe/objectholders/IFPlayer.java
@@ -32,10 +32,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class IFPlayer {
@@ -103,16 +100,12 @@ public class IFPlayer {
         JsonObject json = new JsonObject();
         json.addProperty("uuid", uuid.toString());
         JsonObject preferenceJson = new JsonObject();
-		int propertiesAdded = 0;
         for (Map.Entry<IFPlayerPreference<?>, Object> entry : preferences.entrySet()) {
             IFPlayerPreference<?> preference = entry.getKey();
 			final Object value = entry.getValue();
-			if (value != preference.getDefaultValue(this)) {
-				preferenceJson.add(preference.getJsonName(), preference.getSerializer(Object.class).apply(entry.getValue()));
-				propertiesAdded++;
-			}
+			if (!Objects.equals(value, preference.getDefaultValue(this))) preferenceJson.add(preference.getJsonName(), preference.getSerializer(Object.class).apply(value));
         }
-		if (propertiesAdded == 0) return;
+		if (preferenceJson.size() == 0) return;
         json.add("preferences", preferenceJson);
         try (PrintWriter pw = new PrintWriter(new OutputStreamWriter(Files.newOutputStream(file.toPath()), StandardCharsets.UTF_8))) {
             pw.println(GSON.toJson(json));


### PR DESCRIPTION
Hi there, hope all is well.

On our network, we noticed over 150,000 files within this plugin folder purely having the same default values. With this, I've created a patch that is aimed at eliminating this amount of data (especially at large scales).

Preventing this is quite simple. When serializing the properties, compare each value to the default- if it's the same, there is no reason to store it. After doing so, check the JSON array of serialized properties, and if it's empty, there is no reason to store the player's data entirely. This HEAVILY reduces the amount of data stored.

I'd love for you to look this over, and I appreciate your time.