### PR TITLE
Fix platform scheduler relocation

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -79,7 +79,7 @@
                             <relocations>
                                 <relocation>
                                     <pattern>com.loohp.platformscheduler</pattern>
-                                    <shadedPattern>com.loohp.interactivechat.libs.com.loohp.platformscheduler</shadedPattern>
+                                    <shadedPattern>com.loohp.imageframe.libs.com.loohp.platformscheduler</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.simpleyaml</pattern>


### PR DESCRIPTION
Fixes platform scheduler relocation location, before this seemed to break the plugin on 1.21.7 paper with InteractiveChat installed related to #113 