### PR TITLE
fix: guard MapMeta#getMapView against IllegalStateException

### DIFF
--- a/common/src/main/java/com/loohp/imageframe/objectholders/MapMarkerEditManager.java
+++ b/common/src/main/java/com/loohp/imageframe/objectholders/MapMarkerEditManager.java
@@ -32,7 +32,6 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -46,8 +45,6 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.map.MapCursor;
 import org.bukkit.map.MapView;
 import org.bukkit.util.RayTraceResult;
@@ -110,21 +107,7 @@ public class MapMarkerEditManager implements Listener, AutoCloseable {
             }
             Vector hitPosition = result.getHitPosition();
             ItemStack itemStack = itemFrame.getItem();
-            if (itemStack == null || itemStack.getType().equals(Material.AIR)) {
-                continue;
-            }
-            if (!itemStack.hasItemMeta()) {
-                continue;
-            }
-            ItemMeta itemMeta = itemStack.getItemMeta();
-            if (!(itemMeta instanceof MapMeta)) {
-                continue;
-            }
-            MapMeta mapMeta = (MapMeta) itemMeta;
-            if (!mapMeta.hasMapView()) {
-                continue;
-            }
-            MapView mapView = mapMeta.getMapView();
+            MapView mapView = MapUtils.getItemMapView(itemStack);
             if (mapView == null) {
                 continue;
             }
@@ -194,21 +177,7 @@ public class MapMarkerEditManager implements Listener, AutoCloseable {
             return;
         }
         ItemStack itemStack = itemFrame.getItem();
-        if (itemStack == null || itemStack.getType().equals(Material.AIR)) {
-            return;
-        }
-        if (!itemStack.hasItemMeta()) {
-            return;
-        }
-        ItemMeta itemMeta = itemStack.getItemMeta();
-        if (!(itemMeta instanceof MapMeta)) {
-            return;
-        }
-        MapMeta mapMeta = (MapMeta) itemMeta;
-        if (!mapMeta.hasMapView()) {
-            return;
-        }
-        MapView mapView = mapMeta.getMapView();
+        MapView mapView = MapUtils.getItemMapView(itemStack);
         if (mapView == null) {
             return;
         }

--- a/common/src/main/java/com/loohp/imageframe/utils/ImageFilledMapUtils.java
+++ b/common/src/main/java/com/loohp/imageframe/utils/ImageFilledMapUtils.java
@@ -57,7 +57,7 @@ public class ImageFilledMapUtils {
             return null;
         }
         MapMeta mapMeta = (MapMeta) itemMeta;
-        MapView mapView = mapMeta.hasMapView() ? mapMeta.getMapView() : null;
+        MapView mapView = getMapViewSafely(mapMeta);
         FilledMapItemInfo info = NMS.getInstance().getFilledMapItemInfo(itemStack);
         if (info == null) {
             if (mapView != null) {
@@ -72,13 +72,34 @@ public class ImageFilledMapUtils {
             }
         } else {
             ImageMap imageMap = ImageFrame.imageMapManager.getFromImageId(info.getImageMapIndex());
-            MapView correctMapView = imageMap.getMapViews().get(info.getMapPartIndex());
+            if (imageMap == null || !imageMap.isValid()) {
+                return null;
+            }
+            int mapPartIndex = info.getMapPartIndex();
+            if (mapPartIndex < 0 || mapPartIndex >= imageMap.getMapViews().size()) {
+                return null;
+            }
+            MapView correctMapView = imageMap.getMapViews().get(mapPartIndex);
+            if (correctMapView == null) {
+                return null;
+            }
             if (mapView == null || correctMapView.getId() != mapView.getId()) {
                 mapMeta.setMapView(correctMapView);
                 itemStack.setItemMeta(mapMeta);
             }
         }
         return null;
+    }
+
+    private static MapView getMapViewSafely(MapMeta mapMeta) {
+        try {
+            if (!mapMeta.hasMapView()) {
+                return null;
+            }
+            return mapMeta.getMapView();
+        } catch (IllegalStateException ignored) {
+            return null;
+        }
     }
 
 }

--- a/common/src/main/java/com/loohp/imageframe/utils/MapUtils.java
+++ b/common/src/main/java/com/loohp/imageframe/utils/MapUtils.java
@@ -227,13 +227,22 @@ public class MapUtils {
             return null;
         }
         MapMeta mapMeta = (MapMeta) meta;
-        if (!mapMeta.hasMapView()) {
+        MapView mapView;
+        try {
+            if (!mapMeta.hasMapView()) {
+                return null;
+            }
+            mapView = mapMeta.getMapView();
+        } catch (IllegalStateException ignored) {
+            return null;
+        }
+        if (mapView == null) {
             return null;
         }
         if (mapMeta.hasMapId()) {
             tryDeleteBlankDataFile(getMainWorld(), mapMeta.getMapId());
         }
-        return mapMeta.getMapView();
+        return mapView;
     }
 
     public static MapView getPlayerMapView(Player player) {
@@ -286,18 +295,7 @@ public class MapUtils {
         }
         Vector hitPosition = rayTraceResult.getHitPosition();
         ItemStack itemStack = itemFrame.getItem();
-        if (itemStack == null || itemStack.getType().equals(Material.AIR) || !itemStack.hasItemMeta()) {
-            return null;
-        }
-        ItemMeta itemMeta = itemStack.getItemMeta();
-        if (!(itemMeta instanceof MapMeta)) {
-            return null;
-        }
-        MapMeta mapMeta = (MapMeta) itemMeta;
-        if (!mapMeta.hasMapView()) {
-            return null;
-        }
-        MapView mapView = mapMeta.getMapView();
+        MapView mapView = getItemMapView(itemStack);
         if (mapView == null) {
             return null;
         }


### PR DESCRIPTION
On Leaves/Paper 1.21.10, `MapMeta#getMapView()` can throw -
`IllegalStateException: Item does not have map associated - check hasMapView() first!`
even after `hasMapView()` checks in some cases (invalid/corrupted map meta state).

This caused event handler errors in:
- `EntityPickupItemEvent`
- `InventoryClickEvent`

So, I changed
- Added safe `MapView` retrieval with `try/catch IllegalStateException` in:
  - `ImageFilledMapUtils`
  - `MapUtils#getItemMapView`
- Added null/bounds guards in `ImageFilledMapUtils` for stale map info.
- Reused `MapUtils#getItemMapView` in `MapMarkerEditManager` to avoid direct unsafe calls.

plugin now skips malformed map metadata gracefully instead of throwing and spamming console errors.