### PR TITLE
Add option to skip language download on startup

### DIFF
--- a/common/src/main/java/com/loohp/imageframe/ImageFrame.java
+++ b/common/src/main/java/com/loohp/imageframe/ImageFrame.java
@@ -97,6 +97,8 @@ public class ImageFrame extends JavaPlugin {
 
     public static String language;
 
+    public static boolean downloadLanguagesOnStartup;
+
     public static SimpleDateFormat dateFormat;
 
     public static String mapItemFormat;
@@ -325,6 +327,7 @@ public class ImageFrame extends JavaPlugin {
         viaDisableSmoothAnimationForLegacyPlayers = config.getConfiguration().getBoolean("Hooks.ViaVersion.DisableSmoothAnimationForLegacyPlayers");
 
         language = config.getConfiguration().getString("Settings.Language");
+        downloadLanguagesOnStartup = config.getConfiguration().getBoolean("Settings.DownloadLanguagesOnStartup");
 
         dateFormat = new SimpleDateFormat(config.getConfiguration().getString("Settings.DateFormat"));
 

--- a/common/src/main/java/com/loohp/imageframe/language/LanguageManager.java
+++ b/common/src/main/java/com/loohp/imageframe/language/LanguageManager.java
@@ -78,6 +78,10 @@ public class LanguageManager {
     }
 
     public void downloadTranslations() {
+        if (!ImageFrame.downloadLanguagesOnStartup) {
+            ImageFrame.plugin.getLogger().info("DownloadLanguagesOnStartup is disabled. Skipped downloading language files from the internet; using the locally installed language files.");
+            return;
+        }
         try {
             File languageHashFile = new File(ImageFrame.plugin.getDataFolder(), "language_hashes.json");
             JsonObject languageHashes;
@@ -129,6 +133,7 @@ public class LanguageManager {
                 new IOException("Unable to save language hashes to " + languageHashFile.getAbsolutePath(), e).printStackTrace();
             }
         } catch (Throwable e) {
+            ImageFrame.plugin.getLogger().warning("Failed to fetch language files from the internet. The plugin will use the locally installed language files. If your server cannot reach api.loohpjames.com, or you intend to run it offline, set \"Settings.DownloadLanguagesOnStartup\" to false in config.yml to skip this network request on startup.");
             e.printStackTrace();
         }
     }

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -4,6 +4,10 @@ Settings:
   #For supported languages, see https://loohpjames.com/imageframe/languages/
   #To contribute your language, visit https://crowdin.com/project/imageframe/
   Language: "en_us"
+  #Whether ImageFrame should look for updated language files from the internet on startup
+  #Set to false to skip the network request and only use the locally installed language files
+  #Useful if the server cannot reach api.loohpjames.com, or you intend to run the server offline
+  DownloadLanguagesOnStartup: true
   #Date format used where a time based variable is displayed
   DateFormat: "dd/MM/yyyy HH:mm:ss zzz"
   MapItemFormat: "&f{Name} &7({X}, {Y})"


### PR DESCRIPTION
Servers that cannot reach `api.loohpjames.com` (blocked network, or running offline) currently wait ~30 seconds on every startup. `LanguageManager.downloadTranslations()` makes a synchronous HTTPS request on the server main thread during `onEnable`, so an unreachable API blocks the whole server while the connect times out.

This PR adds a `Settings.DownloadLanguagesOnStartup` config option (default `true`). When set to `false`, the startup network request is skipped and the plugin simply uses the already-installed local language files, so startup completes instantly with no request to `api.loohpjames.com`. It also logs a friendly warning when the fetch fails, pointing users to the new option.
